### PR TITLE
Avoid locale related parsing issues

### DIFF
--- a/source/nanogui/arsdbackend.d
+++ b/source/nanogui/arsdbackend.d
@@ -43,6 +43,13 @@ class ArsdBackend
 {
 	this(int w, int h, string title)
 	{
+		/* Avoid locale-related number parsing issues */
+		version(Windows) {}
+		else {
+			import core.stdc.locale;
+			setlocale(LC_NUMERIC, "C");
+		}
+
 		// we need at least OpenGL3 with GLSL to use NanoVega,
 		// so let's tell simpledisplay about that
 		setOpenGLContextVersion(3, 0);

--- a/source/nanogui/sdlbackend.d
+++ b/source/nanogui/sdlbackend.d
@@ -24,6 +24,13 @@ class SdlBackend : Screen
 {
 	this(int w, int h, string title)
 	{
+		/* Avoid locale-related number parsing issues */
+		version(Windows) {}
+		else {
+			import core.stdc.locale;
+			setlocale(LC_NUMERIC, "C");
+		}
+
 		import gfm.sdl2;
 
 		this.width = w;


### PR DESCRIPTION
Backends should use C locale as the original C++ nanogui does. This avoids floatbox values getting a radix character other than dot on some locales.